### PR TITLE
feat: add preview command support with version management and deployment

### DIFF
--- a/examples/workers-turbo/base.wrangler.jsonc
+++ b/examples/workers-turbo/base.wrangler.jsonc
@@ -7,6 +7,7 @@
   "compatibility_flags": [
     "nodejs_compat"
   ],
+  "preview_urls": true,
   "observability": {
     "enabled": true
   },

--- a/examples/workers-turbo/monocf.config.json
+++ b/examples/workers-turbo/monocf.config.json
@@ -2,8 +2,8 @@
   "rootDir": "./",
   "workersDirName": "workers",
   "baseConfig": "base.wrangler.jsonc",
-  "deploySecrets": true,
-  "deployBindings": true,
+  "deploySecrets": false,
+  "deployBindings": false,
   "variables": {
     "version": "1.0.0"
   }

--- a/src/commands/worker/index.ts
+++ b/src/commands/worker/index.ts
@@ -29,7 +29,7 @@ const workerFlags = {
   }),
   command: workerCommand({
     char: 'c',
-    description: 'Command to execute (dev, deploy)',
+    description: 'Command to execute (dev, deploy, build, preview)',
     required: true,
   }),
   'deploy-secrets': Flags.boolean({
@@ -65,6 +65,21 @@ const workerFlags = {
   minify: Flags.boolean({
     char: 'm',
     description: 'Minify the worker script during build/deploy',
+    required: false,
+  }),
+  message: Flags.string({
+    char: 'M',
+    description: 'Message for the preview version',
+    required: false,
+  }),
+  'from-version': Flags.boolean({
+    char: 'f',
+    description: 'Deploy from an existing version or latest uploaded version',
+    required: false,
+  }),
+  'deploy-from-version-id': Flags.string({
+    char: 'F',
+    description: 'If specified, deploys from an existing version ID instead of latest uploaded version',
     required: false,
   }),
 }

--- a/src/core/commands/worker/wrangler-command.ts
+++ b/src/core/commands/worker/wrangler-command.ts
@@ -61,6 +61,9 @@ export class WranglerCommand extends MonocfCommand<WorkerArgs, WorkerFlags> {
       port: config.port,
       ...(config.command === 'deploy' && {deploySecrets: config.deploySecrets}),
       ...(config.command === 'deploy' && {deployBindings: config.deployBindings}),
+      ...(config.command === 'deploy' && {fromVersion: config.fromVersion}),
+      ...(config.command === 'deploy' && {deployFromVersionId: config.deployFromVersionId}),
+      ...(config.command === 'deploy' && {message: config.message}),
       ...(config.command !== 'dev' && {minify: config.minify}),
     }
 

--- a/src/core/commands/worker/wrangler-command.ts
+++ b/src/core/commands/worker/wrangler-command.ts
@@ -35,8 +35,18 @@ export class WranglerCommand extends MonocfCommand<WorkerArgs, WorkerFlags> {
 
     this.environmentService.setRootDir(config.rootDir)
 
-    if (!config.command || !(config.command === 'deploy' || config.command === 'dev' || config.command === 'build')) {
-      this.errorService.throwConfigurationError('Command is required and must be either "deploy", "dev" or "build"')
+    if (
+      !config.command ||
+      !(
+        config.command === 'preview' ||
+        config.command === 'deploy' ||
+        config.command === 'dev' ||
+        config.command === 'build'
+      )
+    ) {
+      this.errorService.throwConfigurationError(
+        'Command is required and must be either "deploy", "dev", "build" or "preview"',
+      )
     }
 
     // Create command parameters
@@ -51,7 +61,7 @@ export class WranglerCommand extends MonocfCommand<WorkerArgs, WorkerFlags> {
       port: config.port,
       ...(config.command === 'deploy' && {deploySecrets: config.deploySecrets}),
       ...(config.command === 'deploy' && {deployBindings: config.deployBindings}),
-      ...((config.command !== 'dev') && {minify: config.minify}),
+      ...(config.command !== 'dev' && {minify: config.minify}),
     }
 
     // Create command executor
@@ -79,6 +89,11 @@ export class WranglerCommand extends MonocfCommand<WorkerArgs, WorkerFlags> {
           ...params,
           multiWorker: true,
         } as DevCommandParams)
+      } else if (config.command === 'preview') {
+        for (const worker of workers) {
+          params.workerName = worker
+          await commandExecutor.execute(worker, params)
+        }
       }
     } else if (params.workerName) {
       await commandExecutor.execute(params.workerName, params)

--- a/src/core/worker-command-factory/deploy-command.ts
+++ b/src/core/worker-command-factory/deploy-command.ts
@@ -136,8 +136,16 @@ export class DeployCommand implements WorkerCommandExecutor {
 
     // Check if deploying from existing version
     if (params.fromVersion) {
+      this.logService.log(`deploying from existing version`)
       if (!params.deployFromVersionId) {
-        await this.wranglerService.versionDeployCommand(tempWranglerConfigPath, params.env, params.message)
+        this.logService.log(`No specific version ID provided, deploying latest version`)
+        const versions = await this.wranglerService.getVersions(tempWranglerConfigPath, params.env)
+        const latestVersion = versions.pop()
+        if (!latestVersion) {
+          this.errorService.throwWorkerCommandError(`No versions found for worker ${workerName}. Before deploying from version, please create a version using "monocf worker <worker-name> deploy -e <env>"`)
+        }
+
+        await this.wranglerService.versionDeployCommand(tempWranglerConfigPath, params.env, params.message, latestVersion.id)
       } else {
         await this.wranglerService.versionDeployCommand(
           tempWranglerConfigPath,

--- a/src/core/worker-command-factory/index.ts
+++ b/src/core/worker-command-factory/index.ts
@@ -10,6 +10,7 @@ import {WorkerCommand} from '../../types/command-types.js'
 import {BuildCommand} from './build-command.js'
 import {DeployCommand} from './deploy-command.js'
 import {DevCommand} from './dev-command.js'
+import {PreviewCommand} from './preview-command.js'
 import {WorkerCommandExecutor} from './worker-command-executor.js'
 
 /**
@@ -55,6 +56,17 @@ export class WorkerCommandFactory {
 
       case 'deploy': {
         return new DeployCommand(
+          services.errorService,
+          services.fileService,
+          services.wranglerService,
+          services.serviceBindingService,
+          services.environmentService,
+          services.logService,
+        )
+      }
+
+      case 'preview': {
+        return new PreviewCommand(
           services.errorService,
           services.fileService,
           services.wranglerService,

--- a/src/core/worker-command-factory/preview-command.ts
+++ b/src/core/worker-command-factory/preview-command.ts
@@ -8,15 +8,15 @@ import {
   ServiceBindingService,
   WranglerService,
 } from '../../services/index.js'
-import {DeployCommandParams, isDeployCommandParams} from '../../types/command-types.js'
+import {PreviewCommandParams, isPreviewCommandParams} from '../../types/command-types.js'
 import {WRANGLER_FILE} from '../../types/wrangler-types.js'
 import {WorkerCommandExecutor} from './worker-command-executor.js'
 import {experimental_patchConfig} from 'wrangler'
 
 /**
- * Command executor for the deploy command
+ * Command executor for the preview command
  */
-export class DeployCommand implements WorkerCommandExecutor {
+export class PreviewCommand implements WorkerCommandExecutor {
   private errorService: ErrorService
   private fileService: FileService
   private wranglerService: WranglerService
@@ -26,7 +26,7 @@ export class DeployCommand implements WorkerCommandExecutor {
   private deployedServices: Set<string> = new Set<string>()
 
   /**
-   * Creates a new DeployCommand
+   * Creates a new PreviewCommand
    * @param errorService Error service
    * @param fileService File service
    * @param wranglerService Wrangler service
@@ -52,14 +52,14 @@ export class DeployCommand implements WorkerCommandExecutor {
   }
 
   /**
-   * Executes the deploy command
+   * Executes create version upload command
    * @param workerName Worker name
    * @param params Command parameters
    * @returns Promise that resolves when the command completes successfully
    */
-  async execute(workerName: string, params: DeployCommandParams): Promise<void> {
-    if (!isDeployCommandParams(params)) {
-      this.errorService.throwConfigurationError('Invalid command parameters for deploy command')
+  async execute(workerName: string, params: PreviewCommandParams): Promise<void> {
+    if (!isPreviewCommandParams(params)) {
+      this.errorService.throwConfigurationError('Invalid command parameters for preview command')
     }
 
     if (this.fileService.isIgnoredWorker(workerName)) {
@@ -131,28 +131,22 @@ export class DeployCommand implements WorkerCommandExecutor {
 
     experimental_patchConfig(tempWranglerConfigPath, patch, false)
 
-    // Deploy this worker
-    this.logService.log(`Deploying worker ${workerName}`)
+    // upload this worker
+    this.logService.log(`Uploading worker ${workerName}`)
 
-    // Check if deploying from existing version
-    if (params.fromVersion) {
-      if (!params.deployFromVersionId) {
-        await this.wranglerService.versionDeployCommand(tempWranglerConfigPath, params.env, params.message)
-      } else {
-        await this.wranglerService.versionDeployCommand(
-          tempWranglerConfigPath,
-          params.env,
-          params.message,
-          params.deployFromVersionId,
-        )
-      }
-    } else {
-      await this.wranglerService.execWorkerCommand('deploy', [tempWranglerConfigPath], params.env, params.minify)
-    }
+    const version = await this.wranglerService.versionUploadCommand(
+      tempWranglerConfigPath,
+      params.env,
+      params.message,
+      params.minify,
+    )
 
-    // Deploy secrets if needed
+    // save version details to .monocf/versions/{workerName}.json
+    this.fileService.saveWorkerVersionDetails(workerName, version)
+
+    // Deploy secrets if required
     if (params.deploySecrets) {
-      this.logService.log(`Deploying secrets for ${workerName}`)
+      this.logService.log(`Deploying secrets for worker ${workerName}`)
       await this.deploySecrets({
         workerName,
         workerPath,

--- a/src/flags/index.ts
+++ b/src/flags/index.ts
@@ -15,6 +15,9 @@ export interface WorkerFlags {
   workersDirName?: string
   port?: number
   minify?: boolean
+  fromVersion?: boolean
+  deployFromVersionId?: string
+  message?: string
 }
 
 export interface CreateWorkerArgs {

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -54,6 +54,9 @@ export class ConfigurationService {
           command: flags.command,
           port: parsed.port ?? flags.port ?? 8787,
           minify: parsed.minify,
+          fromVersion: flags.fromVersion,
+          deployFromVersionId: flags.deployFromVersionId,
+          message: flags.message,
         }
       } catch (error) {
         this.errorService.throwConfigurationError(`Failed to parse configuration file: ${(error as Error).message}`)

--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -8,7 +8,7 @@ import {FileOperationError} from '../types/error-types.js'
 
 import {experimental_patchConfig, experimental_readRawConfig} from 'wrangler'
 import {getPackageVersion} from '../utils/version.js'
-import {MONOCF_IGNORE_FILE} from '../types/config-types.js'
+import {MONOCF_IGNORE_FILE, VERSIONS_FOLDER} from '../types/config-types.js'
 
 import ignore from 'ignore'
 
@@ -323,5 +323,26 @@ export class FileService {
    */
   isIgnoredWorker(workerName: string): boolean {
     return this.ignoredWorkers.includes(workerName)
+  }
+
+  /**
+   * Saves worker version details to a file
+   * @param workerName Worker name
+   * @param versionDetails Version details to save
+   */
+  saveWorkerVersionDetails(workerName: string, versionDetails: unknown): void {
+    try {
+      const versionsDir = join(VERSIONS_FOLDER, 'versions')
+      if (!existsSync(versionsDir)) {
+        // create directory
+        writeFileSync(versionsDir, '', {flag: 'wx'})
+      }
+      const versionFilePath = join(versionsDir, `${workerName}.json`)
+      writeFileSync(versionFilePath, JSON.stringify(versionDetails, null, 2), {encoding: 'utf8', flag: 'w'})
+    } catch (error) {
+      this.errorService.throwFileOperationError(
+        `Failed to save version details for ${workerName}: ${(error as Error).message}`,
+      )
+    }
   }
 }

--- a/src/services/wrangler-service.ts
+++ b/src/services/wrangler-service.ts
@@ -230,9 +230,11 @@ export class WranglerService {
 
   async versionDeployCommand(configPath: string, env?: string, message?: string, versionId?: string): Promise<void> {
     const args = ['versions', 'deploy', '-c', configPath, '--yes']
+    const triggerArgs = ['triggers', 'deploy', '-c', configPath]
 
     if (env) {
       args.push('--env', env)
+      triggerArgs.push('--env', env)
     }
 
     if (message) {
@@ -244,6 +246,7 @@ export class WranglerService {
     }
 
     await this.executeWranglerCommand(args)
+    await this.executeWranglerCommand(triggerArgs)
   }
 
   /**

--- a/src/services/wrangler-service.ts
+++ b/src/services/wrangler-service.ts
@@ -9,6 +9,7 @@ import {
   WRANGLER_FILE,
   WorkerCommand,
   WranglerError,
+  WorkerVersion,
 } from '../types/index.js'
 import {ErrorService} from './error-service.js'
 import {createSpinner} from 'nanospinner'
@@ -81,6 +82,8 @@ export class WranglerService {
           ),
         )
       })
+
+      this.childProcesses.push(childProcess)
     })
   }
 
@@ -119,7 +122,7 @@ export class WranglerService {
   private spawnHiddenWrangler(args: string[]): ChildProcess {
     const process = spawn('wrangler', args, {
       shell: true,
-      stdio: ['inherit', 'ignore', 'ignore'],
+      stdio: ['inherit', 'pipe', 'ignore'],
     })
 
     return process
@@ -144,13 +147,18 @@ export class WranglerService {
 
   /**
    * Executes a wrangler worker command
-   * @param command Command to execute (dev, deploy)
+   * @param command Command to execute
    * @param configPaths Paths to the wrangler config files
    * @param env Environment to use
    * @param minify Whether to minify the worker (only for deploy)
    * @returns Promise that resolves when the command completes successfully
    */
-  async execWorkerCommand(command: WorkerCommand, configPaths: string[], env?: string, minify?: boolean): Promise<void> {
+  async execWorkerCommand(
+    command: WorkerCommand,
+    configPaths: string[],
+    env?: string,
+    minify?: boolean,
+  ): Promise<void> {
     const args = [command, ...configPaths.flatMap((c) => ['-c', c])]
 
     if (env) {
@@ -162,6 +170,109 @@ export class WranglerService {
     }
 
     return this.executeWranglerCommand(args)
+  }
+
+  /**
+   * Executes a wrangler version upload command
+   * @param configPath Paths to the wrangler config files
+   * @param env Environment to use
+   * @param message Commit message for the version
+   * @param minify Whether to minify the worker
+   * @returns Promise that resolves when the command completes successfully
+   */
+  async versionUploadCommand(
+    configPath: string,
+    env?: string,
+    message?: string,
+    minify?: boolean,
+  ): Promise<{
+    id: string
+    previewUrl: string
+  }> {
+    const args = ['versions upload', '-c', configPath]
+
+    if (env) {
+      args.push('--env', env)
+    }
+
+    if (minify) {
+      args.push('--minify')
+    }
+
+    if (message) {
+      args.push('--message', message)
+    }
+
+    await this.executeWranglerCommand(args)
+
+    // parse preview url and version id from stdout
+    // wrangler does not have a command to get the version id/url after upload
+    // so we need to parse the stdout of the command
+    const child = this.childProcesses[0]
+    let previewUrlMatch: RegExpMatchArray | null = null
+    let versionIdMatch: RegExpMatchArray | null = null
+
+    child.stdout?.on('data', (data: Buffer) => {
+      const output = data.toString()
+      versionIdMatch = output.match(/Worker Version ID: ([a-f0-9-]+)/)
+      previewUrlMatch = output.match(/Version Preview URL: (https:\/\/[^\s]+)/)
+    })
+
+    await new Promise((resolve) => {
+      child.on('close', resolve)
+    })
+
+    return {
+      id: versionIdMatch ? versionIdMatch[1] : '',
+      previewUrl: previewUrlMatch ? previewUrlMatch[1] : '',
+    }
+  }
+
+  async versionDeployCommand(configPath: string, env?: string, message?: string, versionId?: string): Promise<void> {
+    const args = ['versions', 'deploy', '-c', configPath, '--yes']
+
+    if (env) {
+      args.push('--env', env)
+    }
+
+    if (message) {
+      args.push('--message', message)
+    }
+
+    if (versionId) {
+      args.push('--version-id', versionId)
+    }
+
+    await this.executeWranglerCommand(args)
+  }
+
+  /**
+   * Gets the list of versions for a worker
+   * @param configPath Path to the wrangler config file
+   * @param env Environment to use
+   * @returns Promise that resolves to the list of worker versions
+   */
+  async getVersions(configPath: string, env?: string): Promise<WorkerVersion[]> {
+    const args = ['versions', 'list', '-c', configPath, '--json']
+
+    if (env) {
+      args.push('--env', env)
+    }
+
+    const child = this.spawnHiddenWrangler(args)
+
+    const list: WorkerVersion[] = []
+    child.stdout?.on('data', (data: Buffer) => {
+      const output = data.toString()
+      const versions = JSON.parse(output) as WorkerVersion[]
+      list.push(...versions)
+    })
+
+    await new Promise((resolve) => {
+      child.on('close', resolve)
+    })
+
+    return list
   }
 
   async buildWorker(configPath: string, envPath?: string, env?: string, minify?: boolean): Promise<string> {

--- a/src/types/command-types.ts
+++ b/src/types/command-types.ts
@@ -31,7 +31,7 @@ export interface Commander {
 /**
  * Available worker commands
  */
-export type WorkerCommand = 'deploy' | 'dev' | 'build'
+export type WorkerCommand = 'deploy' | 'dev' | 'build' | 'preview'
 
 export type Command = WorkerCommand | 'docker' | 'create'
 
@@ -82,8 +82,32 @@ export interface DeployCommandParams extends BaseCommandParams {
   deploySecrets?: boolean
   /** Whether to deploy service bindings for the worker */
   deployBindings?: boolean
-    /** Whether to minify the output */
+  /** Whether to minify the output */
   minify?: boolean
+  /** Message for the deploy version */
+  message?: string
+  /** Whether to deploy from an existing version */
+  fromVersion?: boolean
+  /** If specified, deploys from an existing version ID instead of creating a new version */
+  deployFromVersionId?: string
+}
+
+/**
+ * Parameters specific to the preview command
+ */
+export interface PreviewCommandParams extends BaseCommandParams {
+  /** Worker name */
+  workerName: string
+  /** Command type */
+  command: 'preview'
+  /** Whether to deploy secrets for the worker */
+  deploySecrets?: boolean
+  /** Whether to deploy service bindings for the worker */
+  deployBindings?: boolean
+  /** Whether to minify the output */
+  minify?: boolean
+  /** Message for the preview version */
+  message?: string
 }
 
 export interface BuildCommandParams extends BaseCommandParams {
@@ -100,7 +124,7 @@ export interface BuildCommandParams extends BaseCommandParams {
 /**
  * Union type of all command parameters
  */
-export type WorkerCommandParams = DevCommandParams | DeployCommandParams | BuildCommandParams
+export type WorkerCommandParams = DevCommandParams | DeployCommandParams | BuildCommandParams | PreviewCommandParams
 
 /**
  * Type guard to check if parameters are for dev command
@@ -127,4 +151,13 @@ export function isDeployCommandParams(params: WorkerCommandParams): params is De
  */
 export function isBuildCommandParams(params: WorkerCommandParams): params is BuildCommandParams {
   return params.command === 'build'
+}
+
+/**
+ * Type guard to check if parameters are for deploy command
+ * @param params Worker command parameters
+ * @returns True if parameters are for deploy command
+ */
+export function isPreviewCommandParams(params: WorkerCommandParams): params is PreviewCommandParams {
+  return params.command === 'preview'
 }

--- a/src/types/config-types.ts
+++ b/src/types/config-types.ts
@@ -29,6 +29,12 @@ export interface CliConfig {
   port?: number
   /** Whether to minify the worker code (only for build command) */
   minify?: boolean
+  /** Whether to deploy from an existing version */
+  fromVersion?: boolean
+  /** Specific version ID to deploy from (only if fromVersion is true) */
+  deployFromVersionId?: string
+  /** Message for the deploy version */
+  message?: string
 }
 
 /**

--- a/src/types/config-types.ts
+++ b/src/types/config-types.ts
@@ -7,6 +7,7 @@ export const DEFAULT_BASE_CONFIG = 'base.wrangler.jsonc'
 export const MONOCF_CONFIG_FILE = 'monocf.config.json'
 export const MONOCF_IGNORE_FILE = '.monocfignore'
 export const MONOCF_FOLDER = './.monocf'
+export const VERSIONS_FOLDER = `${MONOCF_FOLDER}/versions`
 
 /**
  * CLI configuration interface

--- a/src/types/wrangler-types.ts
+++ b/src/types/wrangler-types.ts
@@ -25,3 +25,20 @@ export interface ServiceBindingOptions {
   entrypoint?: string
   props?: Record<string, unknown>
 }
+
+/**
+ * Worker version interface
+ * It is output from `wrangler versions list --json`
+ */
+export interface WorkerVersion {
+  id: string
+  number: number
+  metadata: {
+    created_on: string
+    source: string
+    author_id: string
+    author_email: string
+    has_preview: boolean
+  }
+  annotations: Array<{key: string; value: string}>
+}


### PR DESCRIPTION
Introduce a new preview command that allows deploying from existing versions using version IDs and messages. Update configuration and command handling to support these features.