### PR TITLE
feat: add automatic worker name inference from current directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monocf",
-  "version": "0.0.8",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monocf",
-      "version": "0.0.8",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@bluwy/giget-core": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monocf",
   "description": "MonoCF for manage Cloudflare Workers in monorepo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Omer Demir",
   "bin": {
     "monocf": "./bin/run.js"

--- a/src/core/commands/worker/wrangler-command.ts
+++ b/src/core/commands/worker/wrangler-command.ts
@@ -40,6 +40,7 @@ export class WranglerCommand extends MonocfCommand<WorkerArgs, WorkerFlags> {
     const params: WorkerCommandParams = this.buildParams({
       ...config,
       ...args,
+      workerName: config.workerName,
     })
 
     // Create command executor
@@ -52,13 +53,13 @@ export class WranglerCommand extends MonocfCommand<WorkerArgs, WorkerFlags> {
       logService: this.logService,
     })
 
-    if (!config.all && !args.workerName) {
+    if (!config.all && !config.workerName) {
       this.errorService.throwConfigurationError('Worker name is required if --all flag is not set')
     }
 
     const workers = config.all
       ? this.fileService.getWorkers(config.rootDir, config.workersDirName)
-      : [String(args.workerName)]
+      : [String(config.workerName)]
 
     if (workers.length === 0) {
       this.errorService.throwConfigurationError(`No workers found`)

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -1,5 +1,5 @@
 import {existsSync, readFileSync} from 'node:fs'
-import {join} from 'node:path'
+import {dirname, join, parse, relative, resolve, sep} from 'node:path'
 import {CliConfig, CliFlags, DEFAULT_BASE_CONFIG, MONOCF_CONFIG_FILE} from '../types/config-types.js'
 import {Command} from '../types/command-types.js'
 import {ErrorService} from './error-service.js'
@@ -36,14 +36,21 @@ export class ConfigurationService {
    * @param args Command line arguments
    * @returns Loaded configuration
    */
-  loadConfiguration(flags: WorkerFlags | StartDockerFlags, args: WorkerArgs): CliConfig & CliFlags {
+  loadConfiguration(
+    flags: WorkerFlags | StartDockerFlags,
+    args: WorkerArgs,
+  ): CliConfig & CliFlags & {workerName?: string} {
+    // Search for configuration file up the directory tree
+    const configPath = this.findConfigPath()
+    const cliConfigPath = configPath || join(process.cwd(), MONOCF_CONFIG_FILE)
+    const detectedRootDir = configPath ? dirname(configPath) : process.cwd()
+
     // Load configuration from file
-    const cliConfigPath = join(process.cwd(), MONOCF_CONFIG_FILE)
     if (existsSync(cliConfigPath)) {
       try {
         const parsed: CliConfig = JSON.parse(readFileSync(cliConfigPath, 'utf8'))
         this.cliConfig = {
-          rootDir: parsed.rootDir || process.cwd(),
+          rootDir: parsed.rootDir ? resolve(detectedRootDir, parsed.rootDir) : detectedRootDir,
           workersDirName: parsed.workersDirName || '',
           baseConfig: parsed.baseConfig,
           deploySecrets: parsed.deploySecrets,
@@ -61,6 +68,9 @@ export class ConfigurationService {
       } catch (error) {
         this.errorService.throwConfigurationError(`Failed to parse configuration file: ${(error as Error).message}`)
       }
+    } else {
+      // If no config file found, set default rootDir
+      this.cliConfig.rootDir = detectedRootDir
     }
 
     // Override with command line arguments
@@ -68,8 +78,9 @@ export class ConfigurationService {
     if (flags.workersDirName) this.cliConfig.workersDirName = flags.workersDirName
     if (flags.baseConfig) this.cliConfig.baseConfig = flags.baseConfig
     if (flags.deploySecrets) this.cliConfig.deploySecrets = flags.deploySecrets
+    if (flags.deployBindings) this.cliConfig.deployBindings = flags.deployBindings
     if (flags.minify) this.cliConfig.minify = flags.minify
-    if (this.cliConfig.rootDir === '') this.cliConfig.rootDir = process.cwd()
+    if (this.cliConfig.rootDir === '') this.cliConfig.rootDir = detectedRootDir
 
     // Set default base config if not specified
     if (!this.cliConfig.baseConfig) {
@@ -79,15 +90,74 @@ export class ConfigurationService {
       }
     }
 
-    // Validate configuration
-    this.validateConfiguration(args.workerName)
+    // Infer worker name if not provided
+    const inferredWorkerName = this.inferWorkerName(this.cliConfig.rootDir, this.cliConfig.workersDirName)
+    const effectiveWorkerName = args.workerName || inferredWorkerName
 
-    return this.cliConfig
+    // Validate configuration
+    this.validateConfiguration(effectiveWorkerName)
+
+    return {...this.cliConfig, workerName: effectiveWorkerName}
+  }
+
+  /**
+   * Finds the configuration file path by searching up the directory tree
+   * @returns Path to the configuration file or null if not found
+   */
+  private findConfigPath(): string | null {
+    let currentDir = process.cwd()
+    const {root} = parse(currentDir)
+
+    console.log('currentDir', currentDir)
+    console.log('root', root)
+
+    while (true) {
+      const configPath = join(currentDir, MONOCF_CONFIG_FILE)
+      if (existsSync(configPath)) {
+        console.log('configPath', configPath)
+        return configPath
+      }
+
+      if (currentDir === root) {
+        console.log('return null')
+        return null
+      }
+
+      currentDir = dirname(currentDir)
+    }
+  }
+
+  /**
+   * Infers the worker name from the current directory
+   * @param rootDir Project root directory
+   * @param workersDirName Workers directory name
+   * @returns Inferred worker name or undefined
+   */
+  private inferWorkerName(rootDir: string, workersDirName: string): string | undefined {
+    const cwd = process.cwd()
+    if (!workersDirName) return undefined
+
+    const workersDir = join(rootDir, workersDirName)
+
+    // Check if we are inside the workers directory
+    if (!cwd.startsWith(workersDir)) {
+      return undefined
+    }
+
+    // Get the relative path from workers directory
+    const relativePath = relative(workersDir, cwd)
+    if (!relativePath || relativePath.startsWith('..')) {
+      return undefined
+    }
+
+    // The first segment of the relative path is the worker name
+    const parts = relativePath.split(sep)
+    return parts[0]
   }
 
   /**
    * Validates the configuration
-   * @param workerName Worker name from command line arguments
+   * @param workerName Worker name from command line arguments or inferred
    * @throws {ConfigurationError} If the configuration is invalid
    */
   private validateConfiguration(workerName?: string): void {

--- a/test/wrangler/config/index.test.ts
+++ b/test/wrangler/config/index.test.ts
@@ -1,11 +1,82 @@
 import {expect} from 'chai'
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 import {experimental_readRawConfig} from 'wrangler'
 
-describe('parseJSONC', () => {
-  it('should parse JSONC', () => {
-    const {rawConfig} = experimental_readRawConfig({
-      config: 'test/wrangler.jsonc',
+import {ConfigurationService} from '../../../src/services/configuration-service.js'
+import {ErrorService} from '../../../src/services/error-service.js'
+import {FileService} from '../../../src/services/file-service.js'
+import {MONOCF_CONFIG_FILE} from '../../../src/types/config-types.js'
+import {WRANGLER_FILE} from '../../../src/types/wrangler-types.js'
+
+function createTempProject() {
+  const root = mkdtempSync(join(tmpdir(), 'monocf-config-test-'))
+  const workersDirName = 'workers'
+  const workerName = 'my-worker'
+  const workerDir = join(root, workersDirName, workerName)
+
+  mkdirSync(workerDir, {recursive: true})
+  writeFileSync(
+    join(root, MONOCF_CONFIG_FILE),
+    JSON.stringify(
+      {
+        rootDir: './',
+        workersDirName,
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+  writeFileSync(join(workerDir, WRANGLER_FILE), JSON.stringify({name: workerName}, null, 2), 'utf8')
+
+  return {root, workerDir, workerName, workersDirName}
+}
+
+describe('wrangler config', () => {
+  const originalCwd = process.cwd()
+  let tempRoot: string | undefined
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+
+    if (tempRoot) {
+      rmSync(tempRoot, {recursive: true, force: true})
+      tempRoot = undefined
+    }
+  })
+
+  describe('parseJSONC', () => {
+    it('should parse JSONC', () => {
+      const {rawConfig} = experimental_readRawConfig({
+        config: 'test/wrangler.jsonc',
+      })
+      expect(rawConfig).to.be.an('object')
     })
-    expect(rawConfig).to.be.an('object')
+  })
+
+  describe('ConfigurationService', () => {
+    it('resolves a relative rootDir from the config file location and infers the worker name from cwd', () => {
+      const project = createTempProject()
+      tempRoot = project.root
+      process.chdir(project.workerDir)
+
+      const errorService = new ErrorService()
+      const configurationService = new ConfigurationService(errorService)
+      const fileService = new FileService(errorService)
+
+      const config = configurationService.loadConfiguration(
+        {
+          command: 'build',
+        },
+        {},
+      )
+
+      expect(config.rootDir).to.equal(project.root)
+      expect(config.workersDirName).to.equal(project.workersDirName)
+      expect(config.workerName).to.equal(project.workerName)
+      expect(fileService.getWorkers(config.rootDir, config.workersDirName)).to.deep.equal([project.workerName])
+    })
   })
 })


### PR DESCRIPTION
This pull request improves the configuration handling for worker commands by enhancing how the worker name is determined and making the configuration more robust and user-friendly. The main changes include inferring the worker name based on the current working directory, searching for configuration files up the directory tree, and ensuring consistent use of the resolved worker name throughout the codebase.

**Configuration enhancements:**

* The `ConfigurationService` now searches for the configuration file (`monocf.config.json`) up the directory tree, making it easier to run commands from subdirectories. [[1]](diffhunk://#diff-7a37e031a696a3f84fb8120f8602e35713aafc6a63b8c2eb7caf2787ea3e353bL39-R53) [[2]](diffhunk://#diff-7a37e031a696a3f84fb8120f8602e35713aafc6a63b8c2eb7caf2787ea3e353bR93-R160)
* The service infers the `workerName` automatically if not provided, based on the current working directory relative to the workers directory. This reduces the need for explicit command-line arguments in many cases.
* The loaded configuration now always includes the resolved `workerName`, whether provided directly or inferred. [[1]](diffhunk://#diff-7a37e031a696a3f84fb8120f8602e35713aafc6a63b8c2eb7caf2787ea3e353bL39-R53) [[2]](diffhunk://#diff-7a37e031a696a3f84fb8120f8602e35713aafc6a63b8c2eb7caf2787ea3e353bR93-R160)

**Command logic updates:**

* The `WranglerCommand` class now uses `config.workerName` (the resolved/inferred worker name) instead of `args.workerName` for validation and worker selection, ensuring consistency and supporting the new inference logic. [[1]](diffhunk://#diff-964873059b20ece15b3603a7ae29353d04613d07299ff1e4a996804ef8af15c0R43) [[2]](diffhunk://#diff-964873059b20ece15b3603a7ae29353d04613d07299ff1e4a996804ef8af15c0L55-R62)

**Other improvements:**

* Added support for overriding `deployBindings` from flags, and improved how the root directory is determined when no configuration file is present.
* The configuration validation now works with either the provided or inferred worker name, improving error messages and robustness.